### PR TITLE
Fixed bug in ParameterTester

### DIFF
--- a/core/plugins/debug/src/main/java/imagej/core/plugins/debug/ParameterTester.java
+++ b/core/plugins/debug/src/main/java/imagej/core/plugins/debug/ParameterTester.java
@@ -253,7 +253,7 @@ public class ParameterTester implements ImageJPlugin, PreviewPlugin {
 	}
 
 	private void append(final StringBuilder sb, final String s) {
-		append(sb, s + "\n");
+		sb.append(s + "\n");
 	}
 
 }


### PR DESCRIPTION
Hi all,
If you run the parameter tester plugin and fill in all of its blanks, it will run into a stack overflow exception in ParameterTester.append which, in the master branch, calls itself recursively instead of calling sb.append. So here is a patch.

--Lee
