### PR TITLE
Corrects POM.getPOM for classes located in JARs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ target
 *.iml
 /app/ImageJ.app/
 nb-configuration.xml
+
+*.ipr
+
+*.iws

--- a/core/core/src/main/java/imagej/util/POM.java
+++ b/core/core/src/main/java/imagej/util/POM.java
@@ -8,13 +8,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -26,7 +26,7 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  * The views and conclusions contained in the software and documentation are
  * those of the authors and should not be interpreted as representing official
  * policies, either expressed or implied, of any organization.
@@ -48,7 +48,7 @@ import org.xml.sax.SAXException;
 
 /**
  * Helper class for working with Maven POMs.
- * 
+ *
  * @author Curtis Rueden
  */
 public class POM extends XML {
@@ -99,7 +99,7 @@ public class POM extends XML {
 
 	/**
 	 * Gets the Maven POM associated with the given class.
-	 * 
+	 *
 	 * @param c The class to use as a base when searching for a pom.xml.
 	 * @param groupId The Maven groupId of the desired POM.
 	 * @param artifactId The Maven artifactId of the desired POM.
@@ -113,7 +113,16 @@ public class POM extends XML {
 				// look for pom.xml in JAR's META-INF/maven subdirectory
 				final String pomPath =
 					"META-INF/maven/" + groupId + "/" + artifactId + "/pom.xml";
-				final URL pomURL = new URL("jar:" + location.toString() + "!/" + pomPath);
+                String locationString = location.toString();
+                if (!location.getProtocol().equals("jar")) {
+
+                }
+                String protocolPrefix = location.getProtocol().equals("jar") ? "" : "jar:";
+                String jarPathPrefix = location.toString().endsWith("!/") ? "" : "!/";
+                final URL pomURL = new URL(protocolPrefix +
+                        location.toString() +
+                        jarPathPrefix +
+                        pomPath);
 				final InputStream pomStream = pomURL.openStream();
 				return new POM(pomStream);
 			}


### PR DESCRIPTION
We came across an issue when embedding ImageJ in an other application (a Netbeans RCP app in this case):

ClassUtils.getLocation is returning a URL with suffix "!/", adding an
additional "!/" before pomPath was causing pomURL.openStream to fail.
This patch checks for the !/ suffix (and jar prefix) when creating
pomURL.
