### PR TITLE
Updater (cmd-line): add the 'list-local-only' command

### DIFF
--- a/core/updater/src/main/java/imagej/updater/ui/CommandLine.java
+++ b/core/updater/src/main/java/imagej/updater/ui/CommandLine.java
@@ -171,6 +171,10 @@ public class CommandLine {
 		list(list, files.is(Status.MODIFIED));
 	}
 
+	public void listLocalOnly(final List<String> list) {
+		list(list, files.is(Status.LOCAL_ONLY));
+	}
+
 	public void show(final List<String> list) {
 		for (String filename : list) {
 			show(filename);
@@ -667,6 +671,7 @@ public class CommandLine {
 			+ "\tlist-updateable [<files>]\n"
 			+ "\tlist-modified [<files>]\n"
 			+ "\tlist-current [<files>]\n"
+			+ "\tlist-local-only [<files>]\n"
 			+ "\tshow [<files>]\n"
 			+ "\tupdate [<files>]\n"
 			+ "\tupdate-force [<files>]\n"
@@ -743,6 +748,8 @@ public class CommandLine {
 			makeList(args, 1));
 		else if (command.equals("list-modified")) instance.listModified(
 			makeList(args, 1));
+		else if (command.equals("list-local-only")) instance.listLocalOnly(
+				makeList(args, 1));
 		else if (command.equals("show")) instance.show(makeList(args, 1));
 		else if (command.equals("update")) instance.update(makeList(args, 1));
 		else if (command.equals("update-force")) instance.update(


### PR DESCRIPTION
This command allows you to list the files that have been installed locally
(i.e. not coming from any configured update site). This comes in handy in case
you need to investigate someone else's local installation, e.g. to check for
extra plugins that could be included in a personal update site.
