### PR TITLE
Updater (cmd-line): add the 'list-from-site' command

### DIFF
--- a/core/updater/src/main/java/imagej/updater/ui/CommandLine.java
+++ b/core/updater/src/main/java/imagej/updater/ui/CommandLine.java
@@ -175,8 +175,11 @@ public class CommandLine {
 		list(list, files.is(Status.LOCAL_ONLY));
 	}
 
-	public void listFromSite(final List<String> list) {
-		list(null, files.isUpdateSite(list.get(0)));
+	public void listFromSite(final List<String> sites) {
+		System.out.println("sites.size(): " + sites.size());
+		if (sites.size() != 1)
+			throw die("Usage: list-from-site <name>");
+		list(null, files.isUpdateSite(sites.get(0)));
 	}
 
 	public void show(final List<String> list) {


### PR DESCRIPTION
This command shows all files coming from a specified updated site.

I'm not 100% sure about using `null` as first parameter for the `list()` command, but IMO this is the most consistent way to use the existing functions and structure.
