### PR TITLE
Should be possible to sample a pixel at the maximum of a sampler

### DIFF
--- a/core/data/src/main/java/imagej/data/sampler/SamplingDefinition.java
+++ b/core/data/src/main/java/imagej/data/sampler/SamplingDefinition.java
@@ -185,7 +185,7 @@ public class SamplingDefinition {
 					" for axis " + axis;
 			return false;
 		}
-		if (indices.get(indices.size() - 1) >= dimension) {
+		if (indices.get(indices.size() - 1) > dimension) {
 			err =
 				"Axis range partially beyond dimensions of display " + display.getName() +
 					" for axis " + axis;


### PR DESCRIPTION
Hi all,
I think this fixes the following bug in the latest build:
- Open ImageJ
- File/Open Samples/Clown
- Image/Duplicate

Nothing happens (except the log shows a null pointer exception). The proximate cause, however, is another exception that's thrown because the SamplingDefinition falsely reports that a constraint can't include the realMax of the sampler, but you can sample _at_ the realMax of a sampler.

This patch fixes the bug, hope I understood correctly and it doesn't break something else.

--Lee
