### PR TITLE
Bump pom-scijava to 1.119

### DIFF
--- a/core/legacy/src/main/java/imagej/legacy/IJ1Helper.java
+++ b/core/legacy/src/main/java/imagej/legacy/IJ1Helper.java
@@ -401,6 +401,10 @@ public class IJ1Helper extends AbstractContextual {
 			radioButtons.add(getMacroParameter(label, defaultItem));
 		}
 
+		public List<String> getRadioButtonGroups() {
+			return radioButtons;
+		}
+
 		/** Returns the selected item in the next radio button group. */
 		public String getNextRadioButton() {
 			return radioButtons.get(radioButtonIndex++);

--- a/plugins/commands/src/main/java/imagej/plugins/commands/binary/CloseBinaryImage.java
+++ b/plugins/commands/src/main/java/imagej/plugins/commands/binary/CloseBinaryImage.java
@@ -62,8 +62,8 @@ public class CloseBinaryImage extends AbstractMorphOpsCommand {
 
 	@Override
 	protected void updateDataset(Dataset ds) {
-		Erode opErode = new Erode(getConnectedType(), 1);
-		Dilate opDilate = new Dilate(getConnectedType(), 1);
+		Erode opErode = new Erode(getConnectedType(), null, 1);
+		Dilate opDilate = new Dilate(getConnectedType(), null, 1);
 		Dataset copy = ds.duplicateBlank();
 		Img<BitType> copyData = (Img<BitType>) copy.getImgPlus();
 		Img<BitType> origData = (Img<BitType>) ds.getImgPlus();

--- a/plugins/commands/src/main/java/imagej/plugins/commands/binary/DilateBinaryImage.java
+++ b/plugins/commands/src/main/java/imagej/plugins/commands/binary/DilateBinaryImage.java
@@ -61,7 +61,7 @@ public class DilateBinaryImage extends AbstractMorphOpsCommand {
 
 	@Override
 	protected void updateDataset(Dataset ds) {
-		Dilate op = new Dilate(getConnectedType(), 1);
+		Dilate op = new Dilate(getConnectedType(), null, 1);
 		Dataset copy = ds.duplicate();
 		Img<BitType> copyData = (Img<BitType>) copy.getImgPlus();
 		Img<BitType> resultData = (Img<BitType>) ds.getImgPlus();

--- a/plugins/commands/src/main/java/imagej/plugins/commands/binary/ErodeBinaryImage.java
+++ b/plugins/commands/src/main/java/imagej/plugins/commands/binary/ErodeBinaryImage.java
@@ -61,7 +61,7 @@ public class ErodeBinaryImage extends AbstractMorphOpsCommand {
 
 	@Override
 	protected void updateDataset(Dataset ds) {
-		Erode op = new Erode(getConnectedType(), 1);
+		Erode op = new Erode(getConnectedType(), null, 1);
 		Dataset copy = ds.duplicate();
 		Img<BitType> copyData = (Img<BitType>) copy.getImgPlus();
 		Img<BitType> resultData = (Img<BitType>) ds.getImgPlus();

--- a/plugins/commands/src/main/java/imagej/plugins/commands/binary/OpenBinaryImage.java
+++ b/plugins/commands/src/main/java/imagej/plugins/commands/binary/OpenBinaryImage.java
@@ -62,8 +62,8 @@ public class OpenBinaryImage extends AbstractMorphOpsCommand {
 
 	@Override
 	protected void updateDataset(Dataset ds) {
-		Erode opErode = new Erode(getConnectedType(), 1);
-		Dilate opDilate = new Dilate(getConnectedType(), 1);
+		Erode opErode = new Erode(getConnectedType(), null, 1);
+		Dilate opDilate = new Dilate(getConnectedType(), null, 1);
 		Dataset copy = ds.duplicateBlank();
 		Img<BitType> copyData = (Img<BitType>) copy.getImgPlus();
 		Img<BitType> origData = (Img<BitType>) ds.getImgPlus();

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>1.118</version>
+		<version>1.119</version>
 		<relativePath />
 	</parent>
 


### PR DESCRIPTION
Increases the pom-scijava version to 1.119. This bump updates the
ImgLib2 and ImageJ versions and includes fixes for API changes in these projects.
