### PR TITLE
ImageJ: add accessor for SCIFIO gateway

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
 			<artifactId>imagej-updater</artifactId>
 		</dependency>
 
+		<!-- SCIFIO dependencies -->
+		<dependency>
+			<groupId>io.scif</groupId>
+			<artifactId>scifio</artifactId>
+		</dependency>
+
 		<!-- SciJava dependencies -->
 		<dependency>
 			<groupId>org.scijava</groupId>

--- a/src/main/java/net/imagej/ImageJ.java
+++ b/src/main/java/net/imagej/ImageJ.java
@@ -31,6 +31,8 @@
 
 package net.imagej;
 
+import io.scif.SCIFIO;
+
 import java.util.Collection;
 
 import net.imagej.animation.AnimationService;
@@ -67,6 +69,9 @@ import org.scijava.ui.UIService;
  */
 @Plugin(type = Gateway.class)
 public class ImageJ extends AbstractGateway {
+
+	/** SCIFIO gateway instance, for access to SCIFIO services. */
+	private SCIFIO scifio;
 
 	// -- Constructors --
 
@@ -133,6 +138,13 @@ public class ImageJ extends AbstractGateway {
 	 */
 	public ImageJ(final Context context) {
 		super(ImageJApp.NAME, context);
+		scifio = new SCIFIO(context);
+	}
+
+	// -- ImageJ methods - gateways --
+
+	public SCIFIO scifio() {
+		return scifio;
 	}
 
 	// -- ImageJ methods - services --


### PR DESCRIPTION
The ImageJ gateway did not offer compile-safe access to SCIFIO services.
This accessor provides a way to do so, without cluttering the ImageJ
gateway itself with many new perhaps "niche" services.
