### PR TITLE
Fix markdown syntax for correct display in ImageJ.

### DIFF
--- a/WELCOME.md
+++ b/WELCOME.md
@@ -46,6 +46,7 @@ ImageJ2 is also a collection of reusable software libraries built on the
 framework to facilitate rapid development and painless user customization.
 
 The following software component libraries form the core of ImageJ2:
+
 * [ImageJ Common](https://github.com/imagej/imagej-common) -
   The core image data model, using ImgLib2.
 * [ImageJ OPS](https://github.com/imagej/imagej-ops) -


### PR DESCRIPTION
Markdown text in ImageJ must have a new line between a text paragraph and a
listing otherwise it will be interpreted as running test. This is different
than the Markdown variant of github.
