### PR TITLE
mvn -Papp fixes

### DIFF
--- a/src/main/assembly/application.xml
+++ b/src/main/assembly/application.xml
@@ -85,11 +85,6 @@
 
 		<!-- Include the ImageJ launcher executables in appropriate locations. -->
 		<file>
-			<source>target/imagej-launcher-${imagej-launcher.version}.jar</source>
-			<outputDirectory>jars/</outputDirectory>
-			<destName>imagej-launcher-${imagej-launcher.version}.jar</destName>
-		</file>
-		<file>
 			<source>target/imagej-launcher-linux64</source>
 			<destName>ImageJ-linux64</destName>
 			<fileMode>0755</fileMode>

--- a/src/main/assembly/application.xml
+++ b/src/main/assembly/application.xml
@@ -67,18 +67,18 @@
 
 		<!-- Include the ImageJ2 icon in the Mac OS X application bundle. -->
 		<file>
-			<source>${basedir}/logo/ImageJ.icns</source>
+			<source>${basedir}/logo/imagej2-v1/ImageJ.icns</source>
 			<outputDirectory>/Contents/Resources/</outputDirectory>
 		</file>
 
 		<!-- Use the ImageJ2 logo for the splash screen. -->
 		<file>
-			<source>${basedir}/logo/imagej.png</source>
+			<source>${basedir}/logo/imagej2-v1/imagej.png</source>
 			<outputDirectory>/images/</outputDirectory>
 			<destName>icon.png</destName>
 		</file>
 		<file>
-			<source>${basedir}/logo/imagej.png</source>
+			<source>${basedir}/logo/imagej2-v1/imagej.png</source>
 			<outputDirectory>/images/</outputDirectory>
 			<destName>icon-flat.png</destName>
 		</file>


### PR DESCRIPTION
Hi, 

These commits fixes two build failures (tested with tag 2.2.0) on linux when building with `mvn -Papp`.

`imagej-launcher-${imagej-launcher.version}.jar` does not exist anymore, and was removed in a similar way from pom.xml in https://github.com/imagej/imagej2/commit/c3562b1cf910ab9dad1dd4f735a06d42e89ab3e0. That commit also added net.imagej as a dependency, is that necessary for application.xml as well? 