### PR TITLE
Remove Ona/Gitpod button from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Image.sc Forum](https://img.shields.io/badge/dynamic/json.svg?label=forum&url=https%3A%2F%2Fforum.image.sc%2Ftags%2Fimagej.json&query=%24.topic_list.tags.0.topic_count&colorB=brightgreen&suffix=%20topics&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAABPklEQVR42m3SyyqFURTA8Y2BER0TDyExZ+aSPIKUlPIITFzKeQWXwhBlQrmFgUzMMFLKZeguBu5y+//17dP3nc5vuPdee6299gohUYYaDGOyyACq4JmQVoFujOMR77hNfOAGM+hBOQqB9TjHD36xhAa04RCuuXeKOvwHVWIKL9jCK2bRiV284QgL8MwEjAneeo9VNOEaBhzALGtoRy02cIcWhE34jj5YxgW+E5Z4iTPkMYpPLCNY3hdOYEfNbKYdmNngZ1jyEzw7h7AIb3fRTQ95OAZ6yQpGYHMMtOTgouktYwxuXsHgWLLl+4x++Kx1FJrjLTagA77bTPvYgw1rRqY56e+w7GNYsqX6JfPwi7aR+Y5SA+BXtKIRfkfJAYgj14tpOF6+I46c4/cAM3UhM3JxyKsxiOIhH0IO6SH/A1Kb1WBeUjbkAAAAAElFTkSuQmCC)](https://forum.image.sc/tag/imagej)
 [![Build Status](https://github.com/imagej/imagej2/actions/workflows/build.yml/badge.svg)](https://github.com/imagej/imagej2/actions/workflows/build.yml)
 [![developer chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://imagesc.zulipchat.com/#narrow/stream/327236-ImageJ2)
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/imagej/imagej2)
 
 This is the repository for [ImageJ2](https://imagej.net/software/imagej2),
 a rewrite of the original [ImageJ](https://imagej.net/software/imagej) for


### PR DESCRIPTION
I am unfamiliar with Gitpod, but my understanding is that the Gitpod service as originally advertised has been [AI-ified into "Ona"](https://ona.com/stories/gitpod-is-now-ona). Their [Github repo](https://github.com/gitpod-io/gitpod#gitpod-classic) suggests similar changes. I'm not sure that we want to continue to advertise the ability to write code with that service.